### PR TITLE
Added multiprocessing of segmentation converter

### DIFF
--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -20,6 +20,8 @@ from labelme import utils
 
 class Convertor:
     def __init__(self, CONFIG, input_dir):
+        os.environ["QT_LOGGING_RULES"] = "qt5ct.debug=false"
+
         self.segmentation_class, self.class_rgb = self.get_class(CONFIG)
         _, self.folder_name = os.path.split(input_dir)
         self.origin_image_dir, self.masked_image_dir, self.overlayed_image_dir = \

--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -7,7 +7,6 @@ import base64
 import copy
 import glob
 import json
-import math
 import multiprocessing
 import os
 import sys

--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -44,12 +44,9 @@ class Convertor:
             pool.map(self.multi_convert_json_to_mask, json_list)
         else:
             for i in range(process_num):
-                if not i == process_num:
-                    pool.map(
-                        self.multi_convert_json_to_mask,
-                        json_list[i * num_core : (i+1) * num_core])
-                else:
-                    pool.map(self.multi_convert_json_to_mask, json_list[-process_remainder:])
+                pool.map(
+                    self.multi_convert_json_to_mask,
+                    json_list[i * num_core : (i+1) * num_core])
 
             pool.close()
             pool.join()

--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -39,7 +39,7 @@ class Convertor:
         print('===========================================')
 
         process_num, process_remainder = divmod(len(json_list), num_core)
-        pool = multiprocessing.Pool(processes=len(json_list))
+        pool = multiprocessing.Pool(processes=num_core)
         if len(json_list) <= num_core:
             pool.map(self.multi_convert_json_to_mask, json_list)
         else:


### PR DESCRIPTION
- segment 변환 속도를 빠르게 하기 위해 변환 코드에 multiprocessing을 추가했습니다.
- (xps-15 기준) 한 폴더(이미지 50장)를 변환하는데 multiprocessing `적용 전`은 `48.86`초, `적용 후`는 `1.89`초 소요되는 것을 확인했습니다.
- 리눅스, 윈도우 모두 정상 동작하는 것 확인했습니다.
- 연관 이슈: https://github.com/ROBOTIS-move/labelme/issues/10