### PR TITLE
Modified process core

### DIFF
--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -29,7 +29,14 @@ class Convertor:
 
         json_list = glob.glob(os.path.join(input_dir, '*.json'))
         num_core = multiprocessing.cpu_count()
-        num_core = num_core - (len(json_list) % num_core)
+        if num_core >= 10:
+            num_core = 10
+        elif num_core >= 5:
+            num_core = 5
+        elif num_core >= 2:
+            num_core = 2
+        else:
+            num_core = 1
 
         print('===========================================')
         print('Convert mask image')


### PR DESCRIPTION
- 이미지 변환 시 cpu core 개수에 따라 변환이 안되는 이미지가 발생하는 문제를 해결했습니다.
- 이미지 변환 프로세스에 사용되는 core 개수를 10개 이하이면서 50으로 나누었을 때 나머지가 0인 수로 정했습니다.