### PR TITLE
Modified segmentation label conversion codes

### DIFF
--- a/labelme/cli/class.yaml
+++ b/labelme/cli/class.yaml
@@ -12,6 +12,21 @@ outdoor_segmentation:
   deck : [255, 165, 0]
   grass : [252, 107, 3]
   void : [0, 0, 0]
+indoor_segmentation:
+  in_panel : [128, 128, 128]
+  out_panel : [192, 192, 192]
+  rect-btn : [255, 0, 0]
+  circle-btn : [0, 255, 0]
+  ellipse-btn : [200, 100, 50]
+  rect-circle-btn : [255, 255, 0]
+  rect-rect-btn : [0, 255, 255]
+  special-btn : [255, 0, 255]
+  sticker : [128, 0, 0]
+  admin-key : [128, 128, 0]
+  indicator : [0, 128, 0]
+  handi-symbol : [128, 0, 128]
+  screw : [0, 128, 128]
+  others : [100, 200, 150]
 outdoor_detection:
   ['person',
    'bicycle',

--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -131,7 +131,8 @@ class Convertor:
                 image.shape,
                 polygon_points,
                 detected_labels,
-                self.segmentation_class)
+                self.segmentation_class,
+                file_name=file_name)
 
             label_names = [None] * (max(detected_labels.values()) + 1)
 
@@ -158,7 +159,7 @@ class Convertor:
                 image_name))
 
         except:
-            print('[{0}] folder : {1} error'.format(self.folder_name, file_name))
+            pass
 
 
 def convert_segments(input_dir):

--- a/labelme/cli/draw_segment_label.py
+++ b/labelme/cli/draw_segment_label.py
@@ -22,7 +22,7 @@ class Convertor:
     def __init__(self, CONFIG, input_dir):
         os.environ["QT_LOGGING_RULES"] = "qt5ct.debug=false"
 
-        self.segmentation_class, self.class_rgb = self.get_class(CONFIG)
+        self.config = CONFIG
         _, self.folder_name = os.path.split(input_dir)
         self.origin_image_dir, self.masked_image_dir, self.overlayed_image_dir = \
             self.created_output_dir(input_dir)
@@ -60,10 +60,10 @@ class Convertor:
 
         print('Completed convert [{0}] folder'.format(self.folder_name))
 
-    def get_class(self, CONFIG):
+    def get_class(self, class_type):
         segmentation_class = []
         mask_color_rgb = []
-        for class_name, color in CONFIG['outdoor_segmentation'].items():
+        for class_name, color in self.config[class_type].items():
             segmentation_class.append(class_name)
             mask_color_rgb.append(color)
 
@@ -124,6 +124,7 @@ class Convertor:
             image_name = file_name + '.jpg'
 
             image, json_data = self.load_json_file(json_file)
+            self.segmentation_class, self.class_rgb = self.get_class(json_data['classType'])
             polygon_points = self.get_polygon_point(json_data)
             detected_labels = self.get_label(json_data)
 

--- a/labelme/utils/draw.py
+++ b/labelme/utils/draw.py
@@ -43,7 +43,7 @@ def shape_to_mask(img_shape, points, shape_type=None,
     return mask
 
 
-def getClsId(label, names, seg_class):
+def getClsId(label, names, seg_class, file_name=''):
     if label in seg_class:
         if len(names) == 0:
             cls_id = 1
@@ -57,13 +57,13 @@ def getClsId(label, names, seg_class):
                 cls_id = names.index(label) + 1
 
     else:
-        print("This is segmentation. No object: {}".format(label))
+        print('\033[31m' "[{}] There is no class name: {}".format(file_name, label) + '\033[0m')
         cls_id = 0
         names = None
     return cls_id, names
 
 
-def shapes_to_label(img_shape, shapes, label_name_to_value, seg_class, type='class'):
+def shapes_to_label(img_shape, shapes, label_name_to_value, seg_class, type='class', file_name=''):
     assert type in ['class', 'instance']
     cls = np.zeros(img_shape[:2], dtype=np.int32)
     if type == 'instance':
@@ -84,7 +84,7 @@ def shapes_to_label(img_shape, shapes, label_name_to_value, seg_class, type='cla
                 instance_names.append(label)
             ins_id = instance_names.index(label)
 
-        cls_id, names = getClsId(label, names, seg_class)
+        cls_id, names = getClsId(label, names, seg_class, file_name)
 
         if names == None:
             return None, None


### PR DESCRIPTION
- 엘리베이터 버튼 segmentaion 작업물 변환 및 검토를 위해 기존에 실외 segmentation에서 사용하던 변환 프로그램을 함께 사용 가능한 형태로 변경했습니다.
- 잘못된 이름으로 라벨링 했을 때 segmentation 변환 프로그램에서 발생하는 에러 문구를 더 잘 보이게 개선했습니다.
(연관 이슈: https://github.com/ROBOTIS-move/labelme/issues/34)

![image](https://user-images.githubusercontent.com/58972713/179917599-bbf84ded-e8d9-4bcd-b093-e8fe6d968972.png)
