### PR TITLE
Fixed bugs when editting polygon edges and moving polygon shapes

### DIFF
--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -42,7 +42,7 @@ def get_default_config():
     else:
         create_time = osp.getmtime(user_config_file)
         target_time = time.mktime(
-            datetime.datetime.strptime('2022-01-14 10:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
+            datetime.datetime.strptime('2023-01-16 13:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
         if create_time < target_time:
             try:
                 shutil.copy(config_file, user_config_file)

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -42,7 +42,7 @@ def get_default_config():
     else:
         create_time = osp.getmtime(user_config_file)
         target_time = time.mktime(
-            datetime.datetime.strptime('2022-12-21 10:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
+            datetime.datetime.strptime('2022-01-14 10:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
         if create_time < target_time:
             try:
                 shutil.copy(config_file, user_config_file)

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -265,6 +265,8 @@ class Shape(object):
         min_distance = float("inf")
         post_i = None
         for i in range(len(self.points)):
+            if self.points[i - 1] == self.points[i]:
+                continue
             line = [self.points[i - 1], self.points[i]]
             dist = labelme.utils.distancetoline(point, line)
             if dist <= epsilon and dist < min_distance:
@@ -309,8 +311,8 @@ class Shape(object):
         points = []
         for p in self.points:
             point = p + offset
-            correct_x = point.x() >= 0 and point.x() <= pixemap.width()
-            correct_y = point.y() >= 0 and point.y() <= pixemap.height()
+            correct_x = point.x() >= 0 and point.x() <= pixemap.width() - 1
+            correct_y = point.y() >= 0 and point.y() <= pixemap.height() - 1
             if correct_x and correct_y:
                 points.append(point)
             else:

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -311,8 +311,8 @@ class Shape(object):
         points = []
         for p in self.points:
             point = p + offset
-            correct_x = point.x() >= 0 and point.x() <= pixemap.width() - 1
-            correct_y = point.y() >= 0 and point.y() <= pixemap.height() - 1
+            correct_x = point.x() >= 0 and point.x() < pixemap.width() - 1 + 1e-7
+            correct_y = point.y() >= 0 and point.y() < pixemap.height() - 1 + 1e-7
             if correct_x and correct_y:
                 points.append(point)
             else:

--- a/labelme/shape.py
+++ b/labelme/shape.py
@@ -311,8 +311,8 @@ class Shape(object):
         points = []
         for p in self.points:
             point = p + offset
-            correct_x = point.x() >= 0 and point.x() < pixemap.width() - 1 + 1e-7
-            correct_y = point.y() >= 0 and point.y() < pixemap.height() - 1 + 1e-7
+            correct_x = point.x() >= 0 and point.x() < pixemap.width()
+            correct_y = point.y() >= 0 and point.y() < pixemap.height()
             if correct_x and correct_y:
                 points.append(point)
             else:

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -548,13 +548,13 @@ class Canvas(QtWidgets.QWidget):
         bottom = 0
         for s in self.selectedShapes:
             rect = s.boundingRect()
-            if rect.left() < left:
+            if rect.left() <= left:
                 left = rect.left()
-            if rect.right() > right:
+            if rect.right() >= right:
                 right = rect.right()
-            if rect.top() < top:
+            if rect.top() <= top:
                 top = rect.top()
-            if rect.bottom() > bottom:
+            if rect.bottom() >= bottom:
                 bottom = rect.bottom()
 
         x1 = left - point.x()
@@ -573,15 +573,6 @@ class Canvas(QtWidgets.QWidget):
     def boundedMoveShapes(self, shapes, pos):
         if self.outOfPixmap(pos):
             return False  # No need to move
-        o1 = pos + self.offsets[0]
-        if self.outOfPixmap(o1):
-            pos -= QtCore.QPoint(min(0, o1.x()), min(0, o1.y()))
-        o2 = pos + self.offsets[1]
-        if self.outOfPixmap(o2):
-            pos += QtCore.QPoint(
-                min(0, self.pixmap.width() - o2.x()),
-                min(0, self.pixmap.height() - o2.y()),
-            )
         # XXX: The next line tracks the new position of the cursor
         # relative to the shape, but also results in making it
         # a bit "shaky" when nearing the border and allows it to

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -548,13 +548,13 @@ class Canvas(QtWidgets.QWidget):
         bottom = 0
         for s in self.selectedShapes:
             rect = s.boundingRect()
-            if rect.left() <= left:
+            if rect.left() < left:
                 left = rect.left()
-            if rect.right() >= right:
+            if rect.right() > right:
                 right = rect.right()
-            if rect.top() <= top:
+            if rect.top() < top:
                 top = rect.top()
-            if rect.bottom() >= bottom:
+            if rect.bottom() > bottom:
                 bottom = rect.bottom()
 
         x1 = left - point.x()


### PR DESCRIPTION
- #62 해결을 위해 같은 영역에 여러 폴리곤 점이 찍힐때 예외처리 추가했습니다.
- 라벨링된 폴리곤을 도형을 이미지 경계면에 가깝게 옮길 때 경계면에서 미세하게 튀어나와 불필요한 빈 영역을 발생시키는 버그를 수정했습니다.