### PR TITLE
Added setting specific labels by service area

### DIFF
--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -42,7 +42,7 @@ def get_default_config():
     else:
         create_time = osp.getmtime(user_config_file)
         target_time = time.mktime(
-            datetime.datetime.strptime('2023-01-16 13:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
+            datetime.datetime.strptime('2023-04-18 13:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
         if create_time < target_time:
             try:
                 shutil.copy(config_file, user_config_file)

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -21,15 +21,21 @@ validate_label: null
 
 labels_class:
   outdoor_segmentation:
-    ['pattern-block', 'non-pattern-block', 'curb', 'braille-block', 'cement', 'asphalt',
-    'cross-walk', 'speed-bump', 'sand', 'bicycle-road', 'deck', 'grass', 'pebble', 'void']
+    default:
+      ['pattern-block', 'non-pattern-block', 'curb', 'braille-block', 'cement', 'asphalt',
+      'cross-walk', 'speed-bump', 'sand', 'bicycle-road', 'deck', 'grass', 'pebble', 'void']
+    cma:
+      ['pattern-block', 'non-pattern-block', 'cement',
+      'bicycle-road', 'deck', 'grass', 'pebble', 'void']
   outdoor_detection:
-    ['person', 'car', 'truck', 'bus', 'motorcycle', 'bicycle', 'kickboard',
-    'robot', 'animal', 'mailbox', 'traffic-sign', 'unknown',
-    'stop', 'walk', 'light-out', 'countdown-walk', 'countdown-light-out']
+    default:
+      ['person', 'car', 'truck', 'bus', 'motorcycle', 'bicycle', 'kickboard',
+      'robot', 'animal', 'mailbox', 'traffic-sign', 'unknown',
+      'stop', 'walk', 'light-out', 'countdown-walk', 'countdown-light-out']
   indoor_segmentation:
-    ['in_panel', 'out_panel', 'rect-btn', 'circle-btn', 'ellipse-btn', 'rect-circle-btn', 'rect-rect-btn', 'special-btn',
-    'sticker', 'admin-key', 'indicator', 'handi-symbol', 'screw', 'others']
+    default:
+      ['in_panel', 'out_panel', 'rect-btn', 'circle-btn', 'ellipse-btn', 'rect-circle-btn', 'rect-rect-btn', 'special-btn',
+      'sticker', 'admin-key', 'indicator', 'handi-symbol', 'screw', 'others']
 
 default_shape_color: [0, 0, 255]
 shape_color: manual  # null, 'auto', 'manual'

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -561,7 +561,7 @@ class Canvas(QtWidgets.QWidget):
         y1 = top - point.y()
         x2 = right - point.x()
         y2 = bottom - point.y()
-        self.offsets = QtCore.QPoint(x1, y1), QtCore.QPoint(x2, y2)
+        self.offsets = QtCore.QPoint(int(x1), int(y1)), QtCore.QPoint(int(x2), int(y2))
 
     def boundedMoveVertex(self, pos):
         index, shape = self.hVertex, self.hShape
@@ -648,7 +648,7 @@ class Canvas(QtWidgets.QWidget):
         # Try to move in one direction, and if it fails in another.
         # Give up if both fail.
         point = shapes[0][0]
-        offset = QtCore.QPoint(2.0, 2.0)
+        offset = QtCore.QPoint(2, 2)
         self.offsets = QtCore.QPoint(), QtCore.QPoint()
         self.prevPoint = point
         if not self.boundedMoveShapes(shapes, point - offset):
@@ -724,7 +724,7 @@ class Canvas(QtWidgets.QWidget):
         aw, ah = area.width(), area.height()
         x = (aw - w) / (2 * s) if aw > w else 0
         y = (ah - h) / (2 * s) if ah > h else 0
-        return QtCore.QPoint(x, y)
+        return QtCore.QPoint(int(x), int(y))
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()
@@ -769,11 +769,11 @@ class Canvas(QtWidgets.QWidget):
             # Handle cases where previous point is on one of the edges.
             if x3 == x4:
                 return QtCore.QPoint(
-                    min(max(0, x2), size.width() - 1),
-                    min(max(0, y2), max(y3, y4)))
+                    min(max(0, int(x2)), size.width() - 1),
+                    min(max(0, int(y2)), max(int(y3), int(y4))))
             else:  # y3 == y4
-                return QtCore.QPoint(min(max(0, x2), max(x3, x4)), y3)
-        return QtCore.QPoint(x, y)
+                return QtCore.QPoint(min(max(0, int(x2)), max(int(x3), int(x4))), int(y3))
+        return QtCore.QPoint(int(x), int(y))
 
     def intersectingEdges(self, point1, point2, points):
         """Find intersecting edges.
@@ -800,8 +800,8 @@ class Canvas(QtWidgets.QWidget):
             if 0 <= ua <= 1 and 0 <= ub <= 1:
                 x = x1 + ua * (x2 - x1)
                 y = y1 + ua * (y2 - y1)
-                m = QtCore.QPoint((x3 + x4) / 2, (y3 + y4) / 2)
-                d = labelme.utils.distance(m - QtCore.QPoint(x2, y2))
+                m = QtCore.QPoint(int((x3 + x4) / 2), int((y3 + y4) / 2))
+                d = labelme.utils.distance(m - QtCore.QPoint(int(x2), int(y2)))
                 yield d, i, (x, y)
 
     # These two, along with a call to adjustSize are required for the

--- a/labelme/widgets/image_popup.py
+++ b/labelme/widgets/image_popup.py
@@ -49,6 +49,7 @@ class ImagePopup(QtWidgets.QLabel):
             else:
                 masked_image = os.path.join(self.masked_path, data_name + 'png')
                 if os.path.isfile(masked_image):
+                    self.masked_widget.setWindowTitle('masked image: ' + data_name + 'png')
                     mask, (mask_width, mask_height) = self.load_image(masked_image)
                     mask = QtGui.QImage.fromData(mask)
                     self.masked_widget.setMinimumHeight(mask_height)
@@ -62,6 +63,7 @@ class ImagePopup(QtWidgets.QLabel):
             else:
                 overlayed_image = os.path.join(self.overlayed_path, data_name + 'jpg')
                 if os.path.isfile(overlayed_image):
+                    self.overlayed_widget.setWindowTitle('overlayed image: ' + data_name + 'jpg')
                     overlay, (overlay_width, overlay_height) = self.load_image(overlayed_image)
                     overlay = QtGui.QImage.fromData(overlay)
                     self.overlayed_widget.setMinimumHeight(overlay_height)

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -131,6 +131,19 @@ class LabelDialog(QtWidgets.QDialog):
         if self._sort_labels:
             self.labelList.sortItems()
 
+    def removeLabelHistory(self, source_labels, erase_targets):
+        if len(erase_targets) == 0:
+            return
+        else:
+            if self._sort_labels:
+                source_labels.sort()
+                erase_targets.sort()
+            for iter_index, target_label in enumerate(erase_targets):
+                target_index = source_labels.index(target_label)
+                self.labelList.takeItem(target_index - iter_index)
+        if self._sort_labels:
+            self.labelList.sortItems()
+
     def labelSelected(self, item):
         self.edit.setText(item.text())
 
@@ -250,7 +263,7 @@ class LabelDialog(QtWidgets.QDialog):
                 column = widget_size.height() - self.labelList.size().height() - 180
             else:
                 column = popup_pos.y() - y_margin
-            self.move(QtCore.QPoint(row + x_margin, column + y_margin))
+            self.move(QtCore.QPoint(int(row + x_margin), int(column + y_margin)))
         if self.exec_():
             return self.edit.text(), self.getFlags(), self.getGroupId()
         else:

--- a/labelme/widgets/label_list_widget.py
+++ b/labelme/widgets/label_list_widget.py
@@ -62,8 +62,8 @@ class HTMLDelegate(QtWidgets.QStyledItemDelegate):
     def sizeHint(self, option, index):
         thefuckyourshitup_constant = 4
         return QtCore.QSize(
-            self.doc.idealWidth(),
-            self.doc.size().height() - thefuckyourshitup_constant,
+            int(self.doc.idealWidth()),
+            int(self.doc.size().height() - thefuckyourshitup_constant)
         )
 
 


### PR DESCRIPTION
- #75 이슈에 대응하여 특정 서비스 지역별로 `labels set`을 설정하는 기능을 추가했습니다.
- 해당 기능은 새로운 폴더를 불러올 때 마다 동작합니다.
- `default_config.yaml`폴더 내부의 `label_class`파라미터 구성이 변경되었습니다. 기본적으로 사용하던 `labels set`은 `default`항목에 추가하였고, 이후 특정한 `labels set`을 사용하고 싶으시다면 해당 계층에 새롭게 추가하면 됩니다.
- 라벨 json파일 내부에 `default_config.yaml`과 대응되는 `serviceArea`파라미터를 추가해야 해당 기능이 제대로 동작합니다. 해당 파일의 예시는 #75 에서 확인하실 수 있습니다.
- #74 이슈에 대응하여 `masked image`와 `overlayed image`윈도우에 파일이름을 추가했습니다.