### PR TITLE
Fixed bug of moving box coordinates and modified erasing class list

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -2424,17 +2424,12 @@ class MainWindow(QtWidgets.QMainWindow):
             service_area = None
             if '/' in target_class:
                 class_type, service_area = target_class.split('/')
-                erase_label_names = []
                 if service_area not in self._config['labels_class'][class_type].keys():
                     service_area = 'default'
                 current_label_names = self._config['labels_class'][class_type][service_area]
-                if len(self._last_label_names) != 0:
-                    for last_class_name in self._last_label_names:
-                        if last_class_name not in current_label_names:
-                            erase_label_names.append(last_class_name)
+                self.labelDialog.removeAllLabelHistory(self._last_label_names)
                 for label_name in current_label_names:
                     self.labelDialog.addLabelHistory(label_name)
-                self.labelDialog.removeLabelHistory(self._last_label_names, erase_label_names)
                 self._last_label_names = current_label_names
 
     def get_target_class(self, file_path):

--- a/labelme/config/__init__.py
+++ b/labelme/config/__init__.py
@@ -42,7 +42,7 @@ def get_default_config():
     else:
         create_time = osp.getmtime(user_config_file)
         target_time = time.mktime(
-            datetime.datetime.strptime('2023-10-12 20:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
+            datetime.datetime.strptime('2023-11-14 17:00:00', '%Y-%m-%d %H:%M:%S').timetuple())
         if create_time < target_time:
             try:
                 shutil.copy(config_file, user_config_file)

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -36,11 +36,13 @@ labels_class:
     sga:
       ['pattern-block', 'non-pattern-block', 'cement', 'curb', 'braille-block',
       'asphalt', 'deck', 'manhole', 'wall', 'void', 'pedestrian', 'animal', 'dynamic']
-  outdoor_detection:
+  outdoor_detection-object_detection:
     default:
       ['person', 'car', 'truck', 'bus', 'motorcycle', 'bicycle', 'kickboard',
-      'robot', 'animal', 'mailbox', 'traffic-sign', 'unknown',
-      'stop', 'walk', 'light-out', 'countdown-walk', 'countdown-light-out']
+      'robot', 'animal', 'unknown']
+  outdoor_detection-traffic_light_detection:
+    default:
+      ['stop', 'walk', 'light-out', 'countdown-walk', 'countdown-light-out']
   indoor_segmentation:
     default:
       ['in_panel', 'out_panel', 'rect-btn', 'circle-btn', 'ellipse-btn', 'rect-circle-btn', 'rect-rect-btn', 'special-btn',
@@ -80,9 +82,9 @@ label_colors:
   robot : [0, 0, 128]
   animal : [200, 100, 100]
   mailbox : [128, 0, 128]
-  car : [0, 128, 128]
-  bus : [128, 128, 128]
-  truck : [64, 0, 0]
+  car : [255, 255, 0]
+  bus : [0, 255, 0]
+  truck : [64, 255, 255]
   stop : [192, 0, 0]
   walk : [64, 128, 0]
   light-out : [51, 204, 204]

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -17,7 +17,7 @@ CURSOR_DRAW = QtCore.Qt.CrossCursor
 CURSOR_MOVE = QtCore.Qt.ClosedHandCursor
 CURSOR_GRAB = QtCore.Qt.OpenHandCursor
 
-MOVE_SPEED = 2.0
+MOVE_SPEED = 2
 
 
 class Canvas(QtWidgets.QWidget):
@@ -892,21 +892,21 @@ class Canvas(QtWidgets.QWidget):
                 self.snapping = False
         elif self.editing():
             if key == QtCore.Qt.Key_Up:
-                self.moveByKeyboard(QtCore.QPoint(0.0, -MOVE_SPEED))
+                self.moveByKeyboard(QtCore.QPoint(0, -MOVE_SPEED))
             elif key == QtCore.Qt.Key_Down:
-                self.moveByKeyboard(QtCore.QPoint(0.0, MOVE_SPEED))
+                self.moveByKeyboard(QtCore.QPoint(0, MOVE_SPEED))
             elif key == QtCore.Qt.Key_Left:
-                self.moveByKeyboard(QtCore.QPoint(-MOVE_SPEED, 0.0))
+                self.moveByKeyboard(QtCore.QPoint(-MOVE_SPEED, 0))
             elif key == QtCore.Qt.Key_Right:
-                self.moveByKeyboard(QtCore.QPoint(MOVE_SPEED, 0.0))
+                self.moveByKeyboard(QtCore.QPoint(MOVE_SPEED, 0))
             elif key == 49:
-                self.movePointByKeyboard(QtCore.QPoint(0.0, -MOVE_SPEED))
+                self.movePointByKeyboard(QtCore.QPoint(0, -MOVE_SPEED))
             elif key == 50:
-                self.movePointByKeyboard(QtCore.QPoint(0.0, MOVE_SPEED))
+                self.movePointByKeyboard(QtCore.QPoint(0, MOVE_SPEED))
             elif key == 51:
-                self.movePointByKeyboard(QtCore.QPoint(-MOVE_SPEED, 0.0))
+                self.movePointByKeyboard(QtCore.QPoint(-MOVE_SPEED, 0))
             elif key == 52:
-                self.movePointByKeyboard(QtCore.QPoint(MOVE_SPEED, 0.0))
+                self.movePointByKeyboard(QtCore.QPoint(MOVE_SPEED, 0))
 
     def keyReleaseEvent(self, ev):
         modifiers = ev.modifiers()

--- a/labelme/widgets/label_dialog.py
+++ b/labelme/widgets/label_dialog.py
@@ -131,16 +131,15 @@ class LabelDialog(QtWidgets.QDialog):
         if self._sort_labels:
             self.labelList.sortItems()
 
-    def removeLabelHistory(self, source_labels, erase_targets):
-        if len(erase_targets) == 0:
+    def removeAllLabelHistory(self, source_labels):
+        if len(source_labels) == 0:
             return
         else:
             if self._sort_labels:
                 source_labels.sort()
-                erase_targets.sort()
-            for iter_index, target_label in enumerate(erase_targets):
-                target_index = source_labels.index(target_label)
-                self.labelList.takeItem(target_index - iter_index)
+            for iter_index, source_label in enumerate(source_labels):
+                source_index = source_labels.index(source_label)
+                self.labelList.takeItem(source_index - iter_index)
         if self._sort_labels:
             self.labelList.sortItems()
 


### PR DESCRIPTION
- 박스 좌표를 움직이는 기능(단축키 1~4)을 사용할 때 비정상 종료되는 버그를 수정했습니다.
- 버그의 원인은 좌표 이동 값을 설정할 때 `int`값을 이용해야 하지만 `float`로 설정된 것이었습니다.
- `label_class`의 `outdoor_detection` 항목을 다음 두 가지로 나누어 클래스 선택에 나타나는 클래스 목록이 변경되도록 하였습니다.
  - `outdoor_detection-object_detection`
  - `outdoor_detection-traffic_light_detection`
- 클래스 선택에 나타나는 목록을 수정하는 코드에 버그가 있어 수정하였습니다.
  - 변경 전:
    - 동작 방식: 이전 클래스 목록과 새롭게 세팅된 클래스 목록을 비교하여 제거할 대상을 제거
    - 문제점: 이전 클래스 라벨이 모든 클래스 라벨을 포함하고 있지 않다면 엉뚱한 라벨을 지우는 현상 발견
  - 변경 후:
    - 동작 방식: 이전 클래스 목록을 전부 지우고 새롭게 세팅된 클래스 목록을 추가