### PR TITLE
Updated changelog for bump 5.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog for package labelme
 
 5.12.0 (2023-11-30)
 -------------------
+* Fixed bug of moving box coordinates and modified erasing class list
+* Contributors: Jongsub Yu
 
 5.11.0 (2023-11-09)
 -------------------


### PR DESCRIPTION
- bump 5.12.0을 위해 CHANGELOG.rst 업데이트 했습니다.