### PR TITLE
Updated CHANGELOG for Bump 5.16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog for package labelme
 
 5.16.0 (2024-03-07)
 -------------------
+* Added functionality to track worker task time and new indoor classes
+* Contributors: Dongyun Kim
 
 5.15.0 (2024-02-15)
 -------------------


### PR DESCRIPTION
- Bump 5.16.0을 위해 CHANGELOG를 업데이트 했습니다.