### PR TITLE
Deleted ceiling class for FrontViewSegmentation

### DIFF
--- a/labelme/cli/class.yaml
+++ b/labelme/cli/class.yaml
@@ -238,7 +238,6 @@ FrontViewSegmentation:
   traffic-sign: [64, 0, 128]
   traffic-light-front: [250, 170, 30]
   traffic-light-back: [153, 0, 255]
-  ceiling: [135, 206, 235]
   fence: [190, 153, 153]
   vehicle: [250, 200, 100]
   dynamic: [150, 100, 255]

--- a/labelme/config/default_config.yaml
+++ b/labelme/config/default_config.yaml
@@ -311,7 +311,6 @@ labels_class:
         'traffic-sign',
         'traffic-light-front',
         'traffic-light-back',
-        'ceiling',
         'fence',
         'vehicle',
         'dynamic',
@@ -417,7 +416,6 @@ label_colors:
   pole-group: [116, 27, 71]
   traffic-light-front: [250, 170, 30]
   traffic-light-back: [153, 0, 255]
-  ceiling: [135, 206, 235]
   fence: [190, 153, 153]
   sky: [70, 130, 180]
   forbidden-area: [255, 0, 0]


### PR DESCRIPTION
### 목적
  * FrontViewSegmentation 타입의 ceiling 클래스를 제거하였습니다. 
### 내용
  * FrontViewSegmentation 타입의 ceiling 클래스를 제거하였습니다. 

---
### 기능 동작 검증
  * 로컬 개발 환경에서 테스트 완료`
