### PR TITLE
Fixed shutdown and path bug in windows execution

### DIFF
--- a/exec/build_labelme_windows.py
+++ b/exec/build_labelme_windows.py
@@ -294,6 +294,7 @@ class LabelmeWindowsBuilder:
             "--add-data", f"{self.app_dir}/config;labelme/config",
             "--add-data", f"{self.app_dir}/icons;labelme/icons",
             "--add-data", f"{self.app_dir}/translate;labelme/translate",
+            "--add-data", f"{self.app_dir}/cli;labelme/cli",
 
             # Include all labelme package data
             "--add-data", f"{self.app_dir}/__init__.py;labelme",

--- a/labelme/app.py
+++ b/labelme/app.py
@@ -1637,7 +1637,7 @@ class MainWindow(QtWidgets.QMainWindow):
             flag = item.checkState() == Qt.Checked
             flags[key] = flag
         try:
-            imagePath = osp.relpath(self.imagePath, osp.dirname(filename))
+            imagePath = osp.basename(self.imagePath)
             imageData = None  # self.imageData if self._config["store_data"] else None
             if osp.dirname(filename) and not osp.exists(osp.dirname(filename)):
                 os.makedirs(osp.dirname(filename))

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -776,7 +776,7 @@ class Canvas(QtWidgets.QWidget):
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()
-        return not (0 <= p.x() <= w - 1 and 0 <= p.y() <= h - 1)
+        return not (0 <= p.x() <= w and 0 <= p.y() <= h)
 
     def finalise(self):
         assert self.current

--- a/labelme/widgets/canvas.py
+++ b/labelme/widgets/canvas.py
@@ -776,7 +776,9 @@ class Canvas(QtWidgets.QWidget):
 
     def outOfPixmap(self, p):
         w, h = self.pixmap.width(), self.pixmap.height()
-        return not (0 <= p.x() <= w and 0 <= p.y() <= h)
+        # Allow small tolerance for edge points while maintaining consistency
+        tolerance = 1e-4
+        return not (0 <= p.x() <= w - 1 + tolerance and 0 <= p.y() <= h - 1 + tolerance)
 
     def finalise(self):
         assert self.current

--- a/labelme/widgets/worker_name_dialog.py
+++ b/labelme/widgets/worker_name_dialog.py
@@ -1,6 +1,8 @@
-import sys
-from PyQt5.QtWidgets import QLabel, QLineEdit, QPushButton, QVBoxLayout, QDialog
 import os
+import sys
+
+from PyQt5.QtWidgets import QLabel, QLineEdit, QPushButton, QVBoxLayout, QDialog
+from labelme.utils.measure_working_time import get_worker_name_file_path
 
 
 class WorkerNameWindow(QDialog):
@@ -31,5 +33,8 @@ class WorkerNameWindow(QDialog):
         self.accept()
 
     def write_worker_name(self, worker_name):
-        with open(os.path.join(sys.path[0], 'worker_name.txt'), "a") as f:
+        worker_name_file = get_worker_name_file_path()
+        # Ensure directory exists
+        os.makedirs(os.path.dirname(worker_name_file), exist_ok=True)
+        with open(worker_name_file, "a") as f:
             f.write(worker_name)

--- a/labelme/widgets/worker_name_dialog.py
+++ b/labelme/widgets/worker_name_dialog.py
@@ -34,7 +34,5 @@ class WorkerNameWindow(QDialog):
 
     def write_worker_name(self, worker_name):
         worker_name_file = get_worker_name_file_path()
-        # Ensure directory exists
-        os.makedirs(os.path.dirname(worker_name_file), exist_ok=True)
         with open(worker_name_file, "a") as f:
             f.write(worker_name)


### PR DESCRIPTION
### 목적
  * 버그 수정
### 내용
  * 점이 이미지 모서리에 끝에 존재하여 수정하려 클릭했을 때 프로그램이 자동으로 종료되는 버그를 수정했습니다.
  * 윈도우 실행 파일로 이미지를 수정했을 때 JSON파일의 `imagePath`값에 경로가 들어가 나중에 이미지를 켜지 못하는 버그를 수정했습니다.
---
### 기능 동작 검증
  * `로컬 개발 환경에서 테스트 완료`
